### PR TITLE
refactor!: remove unit from fetch-call

### DIFF
--- a/.github/workflows/pr_check.yml
+++ b/.github/workflows/pr_check.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/setup-node@v1
       with:
-        version: 10
+        node-version: 10
     - uses: actions/checkout@v1
     - name: Install esy
       run: npm install -g esy@0.5.8

--- a/README.md
+++ b/README.md
@@ -4,6 +4,9 @@ Fetch libraries and interface for ReasonML/OCaml.
 
 Fetch aims to provide a common interface over different HTTP and Promise-implementations in the ReasonML/OCaml ecosystem.
 
+> A note is that Fetch is still in a phase where we're figuring out the API. In other words, the API
+> may change and input is welcome!
+
 ## [Fetch Core](./src/fetch-core)
 
 Provides a functor for creating and providing your own Fetch-implementation. The goal is to be pluggable with any HTTP or Promise-implementation provided it conforms to the common interface.

--- a/examples/fetch_native_lwt_get.re
+++ b/examples/fetch_native_lwt_get.re
@@ -1,12 +1,12 @@
 Fetch.(
-  fetch("https://httpbin.org/get", ())
+  fetch("https://httpbin.org/get")
   |> Lwt.map(
        fun
-       | Ok({Response.body, status, url, _}) => {
+       | Ok({Fetch.Response.body, status, url, _}) => {
            Printf.printf(
              "Status-Code: %d\nBody: %s\nUrl: %s",
-             Response.Status.toCode(status),
-             Response.Body.toString(body),
+             Fetch.Response.Status.toCode(status),
+             Fetch.Response.Body.toString(body),
              url,
            );
          }

--- a/examples/fetch_native_lwt_get.re
+++ b/examples/fetch_native_lwt_get.re
@@ -2,11 +2,11 @@ Fetch.(
   fetch("https://httpbin.org/get")
   |> Lwt.map(
        fun
-       | Ok({Fetch.Response.body, status, url, _}) => {
+       | Ok({Response.body, status, url, _}) => {
            Printf.printf(
              "Status-Code: %d\nBody: %s\nUrl: %s",
-             Fetch.Response.Status.toCode(status),
-             Fetch.Response.Body.toString(body),
+             Response.Status.toCode(status),
+             Response.Body.toString(body),
              url,
            );
          }

--- a/examples/fetch_native_lwt_is_succesful.re
+++ b/examples/fetch_native_lwt_is_succesful.re
@@ -5,9 +5,10 @@ let handleResponse =
     | _ => "That's anything but successful. :-("
   );
 
-Fetch.(
-  fetch("http://httpbin.org/get", ())
-  |> Lwt.map(handleResponse)
-  |> Lwt.map(Console.log)
-  |> Lwt_main.run
-);
+let fetchWithAuth = Fetch.fetch(~headers=[("Authorisation", "Bearer xyz")]);
+let fetchWithAuthAndBody = fetchWithAuth(~body="Hello World!");
+
+fetchWithAuthAndBody("https://httpbin.org/get")
+|> Lwt.map(handleResponse)
+|> Lwt.map(Console.log)
+|> Lwt_main.run;

--- a/fetch-native-lwt.json
+++ b/fetch-native-lwt.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@opam/dune": "*",
     "@opam/reason": "*",
-    "fetch-core": "github:lessp/reason-fetch:fetch-core.json#c85c4f9",
+    "fetch-core": "github:lessp/reason-fetch:fetch-core.json#987722f",
     "@reason-native-web/morph_client": "^0.1.1",
     "ocaml": "<4.8.0"
   },

--- a/src/fetch-core/fetchify.re
+++ b/src/fetch-core/fetchify.re
@@ -7,6 +7,6 @@ module Make =
   module Method = Method;
   module Headers = Headers;
 
-  let fetch = (~body=?, ~headers=[], ~meth=`GET, url, ()) =>
+  let fetch = (~body=?, ~headers=[], ~meth=`GET, url) =>
     Request.create(~body, ~headers, ~meth, ~url) |> IO.make;
 };

--- a/src/fetch-core/s.re
+++ b/src/fetch-core/s.re
@@ -46,8 +46,7 @@ module type FETCH = {
       ~body: string=?,
       ~headers: list(Headers.t)=?,
       ~meth: Method.t=?,
-      string,
-      unit
+      string
     ) =>
     t;
 };


### PR DESCRIPTION
BREAKING CHANGE: This would be a breaking change. A url is required, so
the unit-call was unecessary.